### PR TITLE
Add automerge functionality for the flathub bot

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "automerge-flathubbot-prs": true
 }


### PR DESCRIPTION
Enables the external data checker's automerge functionality for successful builds, meaning that successful builds don't require manual merging.