### PR TITLE
rename bin used with zypak-wrapper

### DIFF
--- a/network.loki.Session.json
+++ b/network.loki.Session.json
@@ -59,7 +59,7 @@
                     "dest-filename": "session.sh",
                     "commands": [
                         "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-                        "exec zypak-wrapper /app/Session/session-desktop-bin \"$@\""
+                        "exec zypak-wrapper /app/Session/session-desktop \"$@\""
                     ]
                 },
                 {


### PR DESCRIPTION
the bin used with zypak-wrapper got renamed from `session-desktop-bin` to `session-desktop`

closes: #45 