### PR TITLE
feat(permissions): webcam access

### DIFF
--- a/network.loki.Session.json
+++ b/network.loki.Session.json
@@ -14,7 +14,7 @@
         "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
-        "--device=dri",
+        "--device=all",
         "--filesystem=home",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
@@ -45,8 +45,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/oxen-io/session-desktop/releases/download/v1.7.9/session-desktop-linux-amd64-1.7.9.deb",
-                    "sha256": "b78217687cc0a2f85e634dcf38a51489b29232b5df1c39555ea134e1dec140c5",
+                    "url": "https://github.com/oxen-io/session-desktop/releases/download/v1.8.4/session-desktop-linux-amd64-1.8.4.deb",
+                    "sha256": "25394e17972fb1ff6baf669765c242c1a30e748ecdf92c7d26f9770a0336c3df",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/oxen-io/session-desktop/releases/latest",

--- a/network.loki.Session.metainfo.xml
+++ b/network.loki.Session.metainfo.xml
@@ -58,6 +58,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.8.4" date="2022-04-26"/>
     <release version="1.7.9" date="2022-03-22"/>
     <release version="1.7.8" date="2022-03-17"/>
     <release version="1.7.7" date="2022-02-07"/>


### PR DESCRIPTION
Session 1.8.0 introduces video (& voice) calls. Video calls require webcam access.

This PR adds `--device=all` to this flatpak.

 ~~Draft until 1.8.0 gets released.~~
Version 1.8.4 got released with voice & video calls enabled for everyone.