### PR TITLE
fix(permissions): remove host access

### DIFF
--- a/network.loki.Session.json
+++ b/network.loki.Session.json
@@ -15,7 +15,6 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=home",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--own-name=org.kde.*"


### PR DESCRIPTION
It seems upstream updated to electron `17.1.2` on `v1.8.5` which includes XDG portal support.

There's still some issues that need to be tested before merging ([electron/electron#31258](https://togithub.com/electron/electron/issues/31258) (seems it has been fixed on electron 18)).

Give it a try:

- Make sure you are on Session >= `v1.8.5`

- Use flatseal to remove the `home` filesystem access permission or run the following:
```
flatpak override --user --nofilesystem=home network.loki.Session
```
(remove `--user` if it's not a user install)

- Send an attachment from anywhere

Closes #2 