### PR TITLE
Drop `org.kde.*` own-name

### DIFF
--- a/network.loki.Session.json
+++ b/network.loki.Session.json
@@ -17,8 +17,7 @@
         "--device=all",
         "--filesystem=home",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.kde.StatusNotifierWatcher",
-        "--own-name=org.kde.*"
+        "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [
         {


### PR DESCRIPTION
This is no longer required with newer Electron and runtime

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement
> but known exceptions to this are Electron versions older than 23.3.0.

Current version uses Electron 25.8.1
https://github.com/oxen-io/session-desktop/blob/ff6cbac91268fccb5487c3789ab938f872b17615/package.json#L178