### PR TITLE
Use freedesktop 24.08 SDK & runtime

### DIFF
--- a/network.loki.Session.json
+++ b/network.loki.Session.json
@@ -1,9 +1,9 @@
 {
     "app-id": "network.loki.Session",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "22.08",
+    "base-version": "24.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "session",
     "separate-locales": false,


### PR DESCRIPTION
As the new stable version of Freedesktop SDK is released. This PR updates the SDK and runtime to freedesktop 24.08. This should be done as the current version is already 2 generation behind its using 22.08.

Closes #97 Too.